### PR TITLE
feat: Support floats

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ const frameProcessor = useFrameProcessor((frame) => {
       width: 192,
       height: 192
     },
-    pixelFormat: 'rgb-uint8'
+    pixelFormat: 'rgb',
+    dataType: 'uint8'
   })
-  const array = new Uint8Array(resized)
 
   const firstPixel = {
-    r: array[0],
-    g: array[1],
-    b: array[2]
+    r: resized[0],
+    g: resized[1],
+    b: resized[2]
   }
 }, [])
 ```
@@ -55,7 +55,7 @@ const frameProcessor = createFrameProcessor((frame) => {
 
 ## Pixel Formats
 
-The resize plugin operates in RGB colorspace, and all values are in `uint8`.
+The resize plugin operates in RGB colorspace.
 
 <table>
 <tr>
@@ -67,7 +67,7 @@ The resize plugin operates in RGB colorspace, and all values are in `uint8`.
 </tr>
 
 <tr>
-<td><code>rgb-uint8</code></td>
+<td><code>rgb</code></td>
 <td>R</td>
 <td>G</td>
 <td>B</td>
@@ -75,7 +75,7 @@ The resize plugin operates in RGB colorspace, and all values are in `uint8`.
 </tr>
 
 <tr>
-<td><code>rgba-uint8</code></td>
+<td><code>rgba</code></td>
 <td>R</td>
 <td>G</td>
 <td>B</td>
@@ -83,7 +83,7 @@ The resize plugin operates in RGB colorspace, and all values are in `uint8`.
 </tr>
 
 <tr>
-<td><code>argb-uint8</code></td>
+<td><code>argb</code></td>
 <td>A</td>
 <td>R</td>
 <td>G</td>
@@ -91,7 +91,7 @@ The resize plugin operates in RGB colorspace, and all values are in `uint8`.
 </tr>
 
 <tr>
-<td><code>bgra-uint8</code></td>
+<td><code>bgra</code></td>
 <td>B</td>
 <td>G</td>
 <td>R</td>
@@ -99,7 +99,7 @@ The resize plugin operates in RGB colorspace, and all values are in `uint8`.
 </tr>
 
 <tr>
-<td><code>bgr-uint8</code></td>
+<td><code>bgr</code></td>
 <td>B</td>
 <td>G</td>
 <td>R</td>
@@ -107,7 +107,7 @@ The resize plugin operates in RGB colorspace, and all values are in `uint8`.
 </tr>
 
 <tr>
-<td><code>abgr-uint8</code></td>
+<td><code>abgr</code></td>
 <td>A</td>
 <td>B</td>
 <td>G</td>
@@ -116,14 +116,42 @@ The resize plugin operates in RGB colorspace, and all values are in `uint8`.
 
 </table>
 
+## Data Types
+
+The resize plugin can either convert to uint8 or float32 values:
+
+<table>
+<tr>
+<th>Name</th>
+<th>JS Type</th>
+<th>Value Range</th>
+<th>Example size</th>
+</tr>
+
+<tr>
+<td><code>uint8</code></td>
+<td><code>Uint8Array</code></td>
+<td>0...255</td>
+<td>1920x1080 RGB Frame = ~6.2 MB</td>
+</tr>
+
+<tr>
+<td><code>float32</code></td>
+<td><code>Float32Array</code></td>
+<td>0.0...1.0</td>
+<td>1920x1080 RGB Frame = ~24.8 MB</td>
+</tr>
+
+</table>
+
 ### Performance
 
 If possible, use one of these two formats:
 
-- `argb-uint8`: Can be converted the fastest, but has an additional unused alpha channel.
-- `rgb-uint8`: Requires one more conversion step from `argb-uint8`, but uses 25% less memory due to the removed alpha channel.
+- `argb` in `uint8`: Can be converted the fastest, but has an additional unused alpha channel.
+- `rgb` in `uint8`: Requires one more conversion step from `argb`, but uses 25% less memory due to the removed alpha channel.
 
-All other formats require additional conversion steps, and `float` models have additional memory overhead (up to 4x as big).
+All other formats require additional conversion steps, and `float` models have additional memory overhead (4x as big).
 
 When using TensorFlow Lite, try to convert your model to use `argb-uint8` or `rgb-uint8` as it's input type.
 
@@ -149,7 +177,8 @@ const frameProcessor = useFrameProcessor((frame) => {
       width: 320,
       height: 320,
     },
-    pixelFormat: 'rgb-uint8'
+    pixelFormat: 'rgb',
+    dataType: 'uint8'
   })
   const output = model.runSync([data])
 
@@ -169,7 +198,8 @@ const result = resize(frame, {
     width: 100,
     height: 100,
   },
-  pixelFormat: 'rgb-uint8',
+  pixelFormat: 'rgb',
+  dataType: 'uint8'
 })
 const end = performance.now()
 

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -17,6 +17,7 @@ import io.github.crow_misia.libyuv.Rgb24Buffer
 import io.github.crow_misia.libyuv.RgbaBuffer
 import io.github.crow_misia.libyuv.ext.ImageExt.toI420Buffer
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import kotlin.math.roundToInt
 
 class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin() {
@@ -55,9 +56,15 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
         val destination = _floatDestinationArray!!.byteBuffer
         val source = array.byteBuffer
 
+        // Use little endian as a default byte order
+        source.order(ByteOrder.LITTLE_ENDIAN)
+        destination.order(ByteOrder.LITTLE_ENDIAN)
+
+        // Reset to position 0
         destination.rewind()
         source.rewind()
 
+        // Copy values over as floats
         while (source.hasRemaining()) {
             val uint8Value = source.get()
             val float32Value = uint8Value.toFloat() / 255f

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -53,7 +53,7 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
             _floatDestinationArray = SharedArray(proxy, targetResultSize)
         }
         val destination = _floatDestinationArray!!.byteBuffer
-        val source = _destinationArray!!.byteBuffer
+        val source = array.byteBuffer
 
         destination.rewind()
         source.rewind()

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1120,7 +1120,7 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - VisionCamera (3.8.1):
+  - VisionCamera (3.8.2):
     - React
     - React-callinvoker
     - React-Core
@@ -1389,7 +1389,7 @@ SPEC CHECKSUMS:
   ReactCommon: 45b5d4f784e869c44a6f5a8fad5b114ca8f78c53
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   vision-camera-resize-plugin: b91b0d4bbc2ed14e535358fa744768d64c358fd9
-  VisionCamera: f6ca954813603e753578623fcbb9364d3e08d6ce
+  VisionCamera: edbcd00e27a438b2228f67823e2b8d15a189065f
   Yoga: 13c8ef87792450193e117976337b8527b49e8c03
 
 PODFILE CHECKSUM: 9cf228fb4a0a05c32bc602c7f07154b180219b9e

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1116,7 +1116,7 @@ PODS:
     - React-logger (= 0.73.2)
     - React-perflogger (= 0.73.2)
   - SocketRocket (0.6.1)
-  - vision-camera-resize-plugin (1.0.1):
+  - vision-camera-resize-plugin (1.0.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1388,7 +1388,7 @@ SPEC CHECKSUMS:
   React-utils: f5bc61e7ea3325c0732ae2d755f4441940163b85
   ReactCommon: 45b5d4f784e869c44a6f5a8fad5b114ca8f78c53
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  vision-camera-resize-plugin: e944bb89c8be2b676513869d0b1fb8eaac5e7cfe
+  vision-camera-resize-plugin: b91b0d4bbc2ed14e535358fa744768d64c358fd9
   VisionCamera: f6ca954813603e753578623fcbb9364d3e08d6ce
   Yoga: 13c8ef87792450193e117976337b8527b49e8c03
 

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.73.2",
-    "react-native-vision-camera": "^3.8.1",
+    "react-native-vision-camera": "^3.8.2",
     "react-native-worklets-core": "^0.2.4"
   },
   "devDependencies": {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -30,7 +30,8 @@ export default function App() {
         width: 100,
         height: 100,
       },
-      pixelFormat: 'rgb-uint8',
+      pixelFormat: 'rgb',
+      dataType: 'uint8',
     });
     const array = new Uint8Array(result);
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -33,13 +33,19 @@ export default function App() {
       pixelFormat: 'rgb',
       dataType: 'uint8',
     });
-    const array = new Uint8Array(result);
+    console.log(
+      result[0],
+      result[1],
+      result[2],
+      result[3],
+      '(' + result.length + ')'
+    );
 
     const end = performance.now();
 
     console.log(
       `Resized ${frame.width}x${frame.height} into 100x100 frame (${
-        array.length
+        result.length
       }) in ${(end - start).toFixed(2)}ms`
     );
   }, []);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -30,8 +30,8 @@ export default function App() {
         width: 100,
         height: 100,
       },
-      pixelFormat: 'rgb',
-      dataType: 'float32',
+      pixelFormat: 'argb',
+      dataType: 'uint8',
     });
     console.log(
       result[0],

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -31,7 +31,7 @@ export default function App() {
         height: 100,
       },
       pixelFormat: 'rgb',
-      dataType: 'uint8',
+      dataType: 'float32',
     });
     console.log(
       result[0],

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3538,10 +3538,10 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-native-vision-camera@^3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-3.8.1.tgz#b304b6106e6c50c2d41ea6bc9ed204dcd82ab176"
-  integrity sha512-AqntxRVF8k8OR8+l+mAq7zgZ/O+98ijNeACoViT/htRJe6AbzfmaOej9kLl/qDgu7SKSngXndBlYQe/Yc6o2Bg==
+react-native-vision-camera@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-3.8.2.tgz#f4f75f84c6a19e1c3474ddc0f7f785b5a526739b"
+  integrity sha512-MY39l2e3hNRPUefn2JPShOFExcw0PblbAcUGvJrIfS9pMzdIyceo0umRAx8lOGXzDUAdb+xy/tFWb8zGxKimCQ==
 
 react-native-worklets-core@^0.2.4:
   version "0.2.4"

--- a/ios/FrameBuffer.h
+++ b/ios/FrameBuffer.h
@@ -1,0 +1,58 @@
+//
+//  FrameBuffer.h
+//  VisionCameraResizePlugin
+//
+//  Created by Marc Rousavy on 24.01.24.
+//  Copyright © 2023 Facebook. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <VisionCamera/VisionCameraProxy.h>
+#import <VisionCamera/SharedArray.h>
+#import <Accelerate/Accelerate.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, ConvertPixelFormat) {
+  RGB,
+  ARGB,
+  RGBA,
+  BGR,
+  BGRA,
+  ABGR
+};
+
+typedef NS_ENUM(NSInteger, ConvertDataType) {
+  UINT8,
+  FLOAT32
+};
+
+@interface FrameBuffer : NSObject
+
+- (instancetype)initWithWidth:(size_t)width
+                       height:(size_t)height
+                  pixelFormat:(ConvertPixelFormat)pixelFormat
+                     dataType:(ConvertDataType)dataType
+                        proxy:(VisionCameraProxyHolder*)proxy;
+
+@property(nonatomic, readonly) size_t width;
+@property(nonatomic, readonly) size_t height;
+@property(nonatomic, readonly) ConvertPixelFormat pixelFormat;
+@property(nonatomic, readonly) ConvertDataType dataType;
+
+@property(nonatomic, readonly) size_t channelsPerPixel;
+@property(nonatomic, readonly) size_t bytesPerChannel;
+@property(nonatomic, readonly) size_t bytesPerPixel;
+
+@property(nonatomic, readonly, nonnull) const vImage_Buffer* imageBuffer;
+@property(nonatomic, readonly, nonnull) SharedArray* sharedArray;
+
++ (size_t) getBytesForDataType:(ConvertDataType)type;
++ (size_t) getChannelsPerPixelForFormat:(ConvertPixelFormat)format;
++ (size_t) getBytesPerPixel:(ConvertPixelFormat)format withType:(ConvertDataType)type;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/FrameBuffer.mm
+++ b/ios/FrameBuffer.mm
@@ -1,0 +1,94 @@
+//
+//  FrameBuffer.mm
+//  VisionCameraResizePlugin
+//
+//  Created by Marc Rousavy on 24.01.24.
+//  Copyright © 2023 Facebook. All rights reserved.
+//
+
+#import "FrameBuffer.h"
+
+@implementation FrameBuffer {
+  vImage_Buffer _imageBuffer;
+  SharedArray* _sharedArray;
+}
+
+- (instancetype)initWithWidth:(size_t)width
+                       height:(size_t)height
+                  pixelFormat:(ConvertPixelFormat)pixelFormat
+                     dataType:(ConvertDataType)dataType
+                        proxy:(VisionCameraProxyHolder*)proxy {
+  if (self = [super init]) {
+    _width = width;
+    _height = height;
+    _pixelFormat = pixelFormat;
+    _dataType = dataType;
+    
+    size_t bytesPerPixel = getBytesPerPixel(pixelFormat, dataType);
+    size_t size = width * height * bytesPerPixel;
+    NSLog(@"Allocating SharedArray (size: %zu)...", size);
+    _sharedArray = [[SharedArray alloc] initWithProxy:proxy allocateWithSize:size];
+    _imageBuffer = vImage_Buffer {
+      .width = width,
+      .height = height,
+      .data = _sharedArray.data,
+      .rowBytes = width * bytesPerPixel
+    };
+  }
+  return self;
+}
+
+@synthesize width = _width;
+@synthesize height = _height;
+@synthesize pixelFormat = _pixelFormat;
+@synthesize dataType = _dataType;
+
+- (size_t) channelsPerPixel {
+  return [FrameBuffer getChannelsPerPixelForFormat:_pixelFormat];
+}
+- (size_t) bytesPerChannel {
+  return [FrameBuffer getBytesForDataType:_dataType];
+}
+- (size_t) bytesPerPixel {
+  return self.channelsPerPixel * self.bytesPerChannel;
+}
+
+- (SharedArray*) sharedArray {
+  return _sharedArray;
+}
+
+- (const vImage_Buffer*) imageBuffer {
+  return &_imageBuffer;
+}
+
+
+
++ (size_t) getBytesForDataType:(ConvertDataType)dataType {
+  switch (dataType) {
+    case UINT8:
+      return sizeof(uint8_t);
+    case FLOAT32:
+      return sizeof(float32_t);
+  }
+}
+
++ (size_t) getChannelsPerPixelForFormat:(ConvertPixelFormat)format {
+  switch (format) {
+    case RGB:
+    case BGR:
+      return 3;
+    case RGBA:
+    case ARGB:
+    case BGRA:
+    case ABGR:
+      return 4;
+  }
+}
+
++ (size_t) getBytesPerPixel:(ConvertPixelFormat)format withType:(ConvertDataType)type {
+  size_t channels = [FrameBuffer getChannelsPerPixelForFormat:format];
+  size_t dataTypeSize = [FrameBuffer getBytesForDataType:type];
+  return channels * dataTypeSize;
+}
+
+@end

--- a/ios/FrameBuffer.mm
+++ b/ios/FrameBuffer.mm
@@ -24,7 +24,7 @@
     _pixelFormat = pixelFormat;
     _dataType = dataType;
     
-    size_t bytesPerPixel = getBytesPerPixel(pixelFormat, dataType);
+    size_t bytesPerPixel = [FrameBuffer getBytesPerPixel:pixelFormat withType:dataType];
     size_t size = width * height * bytesPerPixel;
     NSLog(@"Allocating SharedArray (size: %zu)...", size);
     _sharedArray = [[SharedArray alloc] initWithProxy:proxy allocateWithSize:size];

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -190,7 +190,11 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   if (buffer.bytesPerPixel != targetBytesPerPixel) {
     // The bytes per pixel are not the same, so we need an intermediate array allocation.
     if (_convertBuffer == nil || _convertBuffer.width != buffer.width || _convertBuffer.height != buffer.height || _convertBuffer.pixelFormat != destinationFormat) {
-      _convertBuffer = [[FrameBuffer alloc] initWithWidth:buffer.width height:buffer.height pixelFormat:destinationFormat dataType:UINT8 proxy:_proxy];
+      _convertBuffer = [[FrameBuffer alloc] initWithWidth:buffer.width
+                                                   height:buffer.height
+                                              pixelFormat:destinationFormat
+                                                 dataType:UINT8
+                                                    proxy:_proxy];
     }
     destinationBuffer = _convertBuffer;
   }
@@ -278,9 +282,12 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
 
   NSLog(@"Resizing ARGB_8 Frame to %zu x %zu...", width, height);
 
-  size_t resizeArraySize = width * height * buffer.bytesPerPixel;
   if (_resizeBuffer == nil || _resizeBuffer.width != width || _resizeBuffer.height != height) {
-    _resizeBuffer = [[FrameBuffer alloc] initWithWidth:width height:height pixelFormat:ARGB dataType:UINT8 proxy:_proxy];
+    _resizeBuffer = [[FrameBuffer alloc] initWithWidth:width
+                                                height:height
+                                           pixelFormat:ARGB
+                                              dataType:UINT8
+                                                 proxy:_proxy];
     // reset _tempResizeBuffer as well as that depends on the size
     free(_tempResizeBuffer);
     _tempResizeBuffer = nil;

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -153,16 +153,18 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     .rowBytes = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1)
   };
   
-  // TODO: Cache
-  _argbBuffer = [[FrameBuffer alloc] initWithWidth:frame.width
-                                            height:frame.height
-                                       pixelFormat:ARGB
-                                          dataType:UINT8
-                                             proxy:_proxy];
+  if (_argbBuffer == nil || _argbBuffer.width != frame.width || _argbBuffer.height != frame.height) {
+    _argbBuffer = [[FrameBuffer alloc] initWithWidth:frame.width
+                                              height:frame.height
+                                         pixelFormat:ARGB
+                                            dataType:UINT8
+                                               proxy:_proxy];
+  }
+  const vImage_Buffer* destination = _argbBuffer.imageBuffer;
 
   error = vImageConvert_420Yp8_CbCr8ToARGB8888(&sourceY,
                                                &sourceCbCr,
-                                               _argbBuffer.imageBuffer,
+                                               destination,
                                                &info,
                                                nil,
                                                255,


### PR DESCRIPTION
Adds support to convert to float types.

BREAKING CHANGE: The API has changed a bit. see readme for more info

Changes:

- Return type is no longer `ArrayBuffer`, but either `Uint8Array` or `Float32Array` depending on the input `dataType`.
- Pixel Formats have been renamed from `rgb-uint8` to `rgb`.
- Data Type has been added, either `uint8` or `float32`