### PR TITLE
fix: Validate input Image Format

### DIFF
--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -1,6 +1,7 @@
 package com.visioncameraresizeplugin
 
 import android.media.Image
+import android.graphics.ImageFormat
 import android.util.Log
 import androidx.annotation.Keep
 import com.facebook.jni.HybridData
@@ -80,7 +81,13 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
             Log.i(TAG, "Target DataType: $targetType")
         }
 
-        val resized = resize(frame.image,
+        val image = frame.image
+
+        if (image.format != ImageFormat.YUV_420_888) {
+            throw Error("Frame has invalid PixelFormat! Only YUV_420_888 is supported. Did you set pixelFormat=\"yuv\"?")
+        }
+
+        val resized = resize(image,
                 targetX, targetY,
                 targetWidth, targetHeight,
                 targetFormat.ordinal, targetType.ordinal)


### PR DESCRIPTION
Validate if the input `Frame` is in `yuv` (`ImageFormat.YUV_420_888`).

This plugin only works in YUV, no RGB or PRIVATE. Cameras should generally alwasy be YUV imo. 

So this means, to use it you have to do

```tsx
<Camera pixelFormat="yuv" {...props} />
```

Related to https://github.com/mrousavy/vision-camera-resize-plugin/issues/21