### PR TITLE
feat: Add `crop` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ const frameProcessor = useFrameProcessor((frame) => {
   'worklet'
 
   const resized = resize(frame, {
-    size: {
-      x: 10,
-      y: 10,
+    scale: {
       width: 192,
       height: 192
     },
@@ -175,10 +173,7 @@ const frameProcessor = useFrameProcessor((frame) => {
   'worklet'
 
   const data = resize(frame, {
-    size: {
-      // center-crop
-      x: (frame.width / 2) - (320 / 2),
-      y: (frame.height / 2) - (320 / 2),
+    scale: {
       width: 320,
       height: 320,
     },
@@ -199,9 +194,7 @@ I benchmarked vision-camera-resize-plugin on an iPhone 15 Pro, using the followi
 ```tsx
 const start = performance.now()
 const result = resize(frame, {
-  size: {
-    x: 0,
-    y: 0,
+  scale: {
     width: 100,
     height: 100,
   },

--- a/android/src/main/cpp/ResizePlugin.cpp
+++ b/android/src/main/cpp/ResizePlugin.cpp
@@ -257,9 +257,10 @@ FrameBuffer ResizePlugin::convertBufferToDataType(FrameBuffer frameBuffer, DataT
 }
 
 jni::global_ref<jni::JByteBuffer> ResizePlugin::resize(jni::alias_ref<JImage> image,
-                                                      int cropX, int cropY,
-                                                      int targetWidth, int targetHeight,
-                                                      int /* PixelFormat */ pixelFormatOrdinal, int /* DataType */ dataTypeOrdinal) {
+                                                       int cropX, int cropY,
+                                                       int cropWidth, int cropHeight,
+                                                       int scaleWidth, int scaleHeight,
+                                                       int /* PixelFormat */ pixelFormatOrdinal, int /* DataType */ dataTypeOrdinal) {
   PixelFormat pixelFormat = static_cast<PixelFormat>(pixelFormatOrdinal);
   DataType dataType = static_cast<DataType>(dataTypeOrdinal);
 
@@ -267,7 +268,7 @@ jni::global_ref<jni::JByteBuffer> ResizePlugin::resize(jni::alias_ref<JImage> im
   FrameBuffer result = imageToFrameBuffer(image);
 
   // 2. Crop ARGB
-  result = cropARGBBuffer(result, cropX, cropY, targetWidth, targetHeight);
+  result = cropARGBBuffer(result, cropX, cropY, cropWidth, cropHeight);
 
   // 3. Convert from ARGB -> ????
   result = convertARGBBufferTo(result, pixelFormat);

--- a/android/src/main/cpp/ResizePlugin.cpp
+++ b/android/src/main/cpp/ResizePlugin.cpp
@@ -122,7 +122,7 @@ std::string rectToString(int x, int y, int width, int height) {
 FrameBuffer ResizePlugin::cropARGBBuffer(vision::FrameBuffer frameBuffer,
                                          int x, int y,
                                          int width, int height) {
-  if (width == frameBuffer.width && height == frameBuffer.height) {
+  if (width == frameBuffer.width && height == frameBuffer.height && x == 0 && y == 0) {
     // already in correct size.
     return frameBuffer;
   }
@@ -135,15 +135,15 @@ FrameBuffer ResizePlugin::cropARGBBuffer(vision::FrameBuffer frameBuffer,
   size_t channels = getChannelCount(PixelFormat::ARGB);
   size_t channelSize = getBytesPerChannel(DataType::UINT8);
   size_t argbSize = width * height * channels * channelSize;
-  if (_resizeBuffer == nullptr || _resizeBuffer->getDirectSize() != argbSize) {
-    _resizeBuffer = allocateBuffer(argbSize, "_resizeBuffer");
+  if (_cropBuffer == nullptr || _cropBuffer->getDirectSize() != argbSize) {
+    _cropBuffer = allocateBuffer(argbSize, "_cropBuffer");
   }
   FrameBuffer destination = {
       .width = width,
       .height = height,
       .pixelFormat = PixelFormat::ARGB,
       .dataType = DataType::UINT8,
-      .buffer = _resizeBuffer,
+      .buffer = _cropBuffer,
   };
 
   int status = libyuv::ConvertToARGB(frameBuffer.data(), frameBuffer.height * frameBuffer.bytesPerRow(),
@@ -157,6 +157,46 @@ FrameBuffer ResizePlugin::cropARGBBuffer(vision::FrameBuffer frameBuffer,
   }
 
   return destination;
+}
+
+
+FrameBuffer ResizePlugin::scaleARGBBuffer(vision::FrameBuffer frameBuffer,
+                                          int width, int height) {
+    if (width == frameBuffer.width && height == frameBuffer.height) {
+        // already in correct size.
+        return frameBuffer;
+    }
+
+    auto rectString = rectToString(0, 0, frameBuffer.width, frameBuffer.height);
+    auto targetString = rectToString(0, 0, width, height);
+    __android_log_print(ANDROID_LOG_INFO, TAG, "Scaling [%s] ARGB buffer to [%s]...",
+                        rectString.c_str(), targetString.c_str());
+
+    size_t channels = getChannelCount(PixelFormat::ARGB);
+    size_t channelSize = getBytesPerChannel(DataType::UINT8);
+    size_t argbSize = width * height * channels * channelSize;
+    if (_scaleBuffer == nullptr || _scaleBuffer->getDirectSize() != argbSize) {
+        _scaleBuffer = allocateBuffer(argbSize, "_scaleBuffer");
+    }
+    FrameBuffer destination = {
+            .width = width,
+            .height = height,
+            .pixelFormat = PixelFormat::ARGB,
+            .dataType = DataType::UINT8,
+            .buffer = _scaleBuffer,
+    };
+
+
+    int status = libyuv::ARGBScale(frameBuffer.data(), frameBuffer.bytesPerRow(),
+                                   frameBuffer.width, frameBuffer.height,
+                                   destination.data(), destination.bytesPerRow(),
+                                   width, height,
+                                   libyuv::FilterMode::kFilterBilinear);
+    if (status != 0) {
+        throw std::runtime_error("Failed to scale ARGB Buffer! Status: " + std::to_string(status));
+    }
+
+    return destination;
 }
 
 FrameBuffer ResizePlugin::convertARGBBufferTo(FrameBuffer frameBuffer, PixelFormat pixelFormat) {
@@ -270,10 +310,13 @@ jni::global_ref<jni::JByteBuffer> ResizePlugin::resize(jni::alias_ref<JImage> im
   // 2. Crop ARGB
   result = cropARGBBuffer(result, cropX, cropY, cropWidth, cropHeight);
 
-  // 3. Convert from ARGB -> ????
+  // 3. Scale ARGB
+  result = scaleARGBBuffer(result, scaleWidth, scaleHeight);
+
+  // 4. Convert from ARGB -> ????
   result = convertARGBBufferTo(result, pixelFormat);
 
-  // 4. Convert from data type to other data type
+  // 5. Convert from data type to other data type
   result = convertBufferToDataType(result, dataType);
 
   return result.buffer;

--- a/android/src/main/cpp/ResizePlugin.cpp
+++ b/android/src/main/cpp/ResizePlugin.cpp
@@ -186,7 +186,6 @@ FrameBuffer ResizePlugin::scaleARGBBuffer(vision::FrameBuffer frameBuffer,
             .buffer = _scaleBuffer,
     };
 
-
     int status = libyuv::ARGBScale(frameBuffer.data(), frameBuffer.bytesPerRow(),
                                    frameBuffer.width, frameBuffer.height,
                                    destination.data(), destination.bytesPerRow(),

--- a/android/src/main/cpp/ResizePlugin.h
+++ b/android/src/main/cpp/ResizePlugin.h
@@ -58,6 +58,7 @@ private:
 
   FrameBuffer imageToFrameBuffer(alias_ref<JImage> image);
   FrameBuffer cropARGBBuffer(FrameBuffer frameBuffer, int x, int y, int width, int height);
+  FrameBuffer scaleARGBBuffer(FrameBuffer frameBuffer, int width, int height);
   FrameBuffer convertARGBBufferTo(FrameBuffer frameBuffer, PixelFormat toFormat);
   FrameBuffer convertBufferToDataType(FrameBuffer frameBuffer, DataType dataType);
 
@@ -70,7 +71,8 @@ private:
   // YUV (?x?) -> ARGB (?x?)
   global_ref<JByteBuffer> _argbBuffer;
   // ARGB (?x?) -> ARGB (!x!)
-  global_ref<JByteBuffer> _resizeBuffer;
+  global_ref<JByteBuffer> _cropBuffer;
+  global_ref<JByteBuffer> _scaleBuffer;
   // ARGB (?x?) -> !!!! (?x?)
   global_ref<JByteBuffer> _customFormatBuffer;
   // Custom Data Type (e.g. float32)

--- a/android/src/main/cpp/ResizePlugin.h
+++ b/android/src/main/cpp/ResizePlugin.h
@@ -51,9 +51,10 @@ private:
   explicit ResizePlugin(const alias_ref<jhybridobject>& javaThis);
 
   global_ref<JByteBuffer> resize(alias_ref<JImage> image,
-                                int cropX, int cropY,
-                                int targetWidth, int targetHeight,
-                                int /* PixelFormat */ pixelFormat, int /* DataType */ dataType);
+                                 int cropX, int cropY,
+                                 int cropWidth, int cropHeight,
+                                 int scaleWidth, int scaleHeight,
+                                 int /* PixelFormat */ pixelFormat, int /* DataType */ dataType);
 
   FrameBuffer imageToFrameBuffer(alias_ref<JImage> image);
   FrameBuffer cropARGBBuffer(FrameBuffer frameBuffer, int x, int y, int width, int height);

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -80,15 +80,15 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
             }
         } else {
             if (scale != null) {
-                val aspectRatio = frame.width / frame.height
-                val targetAspectRatio = scaleWidth / scaleHeight
+                val aspectRatio = frame.width.toDouble() / frame.height.toDouble()
+                val targetAspectRatio = scaleWidth.toDouble() / scaleHeight.toDouble()
 
                 if (aspectRatio > targetAspectRatio) {
-                    cropWidth = frame.height * targetAspectRatio
+                    cropWidth = (frame.height * targetAspectRatio).toInt()
                     cropHeight = frame.height
                 } else {
                     cropWidth = frame.width
-                    cropHeight = frame.width / targetAspectRatio
+                    cropHeight = (frame.width / targetAspectRatio).toInt()
                 }
                 cropX = (frame.width / 2) - (cropWidth / 2)
                 cropY = (frame.height / 2) - (cropHeight / 2)

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -84,11 +84,11 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
                 val targetAspectRatio = scaleWidth / scaleHeight
 
                 if (aspectRatio > targetAspectRatio) {
-                    cropWidth = frame.width * targetAspectRatio
+                    cropWidth = frame.height * targetAspectRatio
                     cropHeight = frame.height
                 } else {
                     cropWidth = frame.width
-                    cropHeight = frame.height / targetAspectRatio
+                    cropHeight = frame.width / targetAspectRatio
                 }
                 cropX = (frame.width / 2) - (cropWidth / 2)
                 cropY = (frame.height / 2) - (cropHeight / 2)

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -84,11 +84,11 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
                 val targetAspectRatio = scaleWidth / scaleHeight
 
                 if (aspectRatio > targetAspectRatio) {
-                    cropWidth = frame.height * targetAspectRatio
+                    cropWidth = frame.width * targetAspectRatio
                     cropHeight = frame.height
                 } else {
                     cropWidth = frame.width
-                    cropHeight = frame.width / targetAspectRatio
+                    cropHeight = frame.height / targetAspectRatio
                 }
                 cropX = (frame.width / 2) - (cropWidth / 2)
                 cropY = (frame.height / 2) - (cropHeight / 2)

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -32,7 +32,8 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
     private external fun initHybrid(): HybridData
     private external fun resize(image: Image,
                                 cropX: Int, cropY: Int,
-                                targetWidth: Int, targetHeight: Int,
+                                cropWidth: Int, cropHeight: Int,
+                                scaleWidth: Int, scaleHeight: Int,
                                 pixelFormat: Int, dataType: Int): ByteBuffer
 
     override fun callback(frame: Frame, params: MutableMap<String, Any>?): Any {
@@ -40,31 +41,60 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
             throw Error("Options cannot be null!")
         }
 
-        var targetWidth = frame.width
-        var targetHeight = frame.height
-        var targetX = 0
-        var targetY = 0
+        var cropWidth = frame.width
+        var cropHeight = frame.height
+        var cropX = 0
+        var cropY = 0
+        var scaleWidth = frame.width
+        var scaleHeight = frame.height
         var targetFormat = PixelFormat.ARGB
         var targetType = DataType.UINT8
 
-        val targetSize = params["size"] as? Map<*, *>
-        if (targetSize != null) {
-            val targetWidthDouble = targetSize["width"] as? Double
-            val targetHeightDouble = targetSize["height"] as? Double
-            val targetXDouble = targetSize["x"] as? Double
-            val targetYDouble = targetSize["y"] as? Double
-            if (targetWidthDouble != null && targetHeightDouble != null) {
-                targetWidth = targetWidthDouble.toInt()
-                targetHeight = targetHeightDouble.toInt()
-                if (targetXDouble != null && targetYDouble != null) {
-                    targetX = targetXDouble.toInt()
-                    targetY = targetYDouble.toInt()
+        val scale = params["scale"] as? Map<*, *>
+        if (scale != null) {
+            val scaleWidthDouble = scale["width"] as? Double
+            val scaleHeightDouble = scale["height"] as? Double
+            if (scaleWidthDouble != null && scaleHeightDouble != null) {
+                scaleWidth = scaleWidthDouble.toInt()
+                scaleHeight = scaleHeightDouble.toInt()
+            } else {
+                throw Error("Failed to parse values in scale dictionary!")
+            }
+            Log.i(TAG, "Target scale: $scaleWidth x $scaleHeight")
+        }
+
+        val crop = params["crop"] as? Map<*, *>
+        if (crop != null) {
+            val cropWidthDouble = crop["width"] as? Double
+            val cropHeightDouble = crop["height"] as? Double
+            val cropXDouble = crop["x"] as? Double
+            val cropYDouble = crop["y"] as? Double
+            if (cropWidthDouble != null && cropHeightDouble != null && cropXDouble != null && cropYDouble != null) {
+                cropWidth = cropWidthDouble.toInt()
+                cropHeight = cropHeightDouble.toInt()
+                cropX = cropXDouble.toInt()
+                cropY = cropYDouble.toInt()
+                Log.i(TAG, "Target size: $cropWidth x $cropHeight")
+            } else {
+                throw Error("Failed to parse values in crop dictionary!")
+            }
+        } else {
+            if (scale != null) {
+                val aspectRatio = frame.width / frame.height
+                val targetAspectRatio = scaleWidth / scaleHeight
+
+                if (aspectRatio > targetAspectRatio) {
+                    cropWidth = frame.height * targetAspectRatio
+                    cropHeight = frame.height
                 } else {
-                    // by default, do a center crop
-                    targetX = (frame.width / 2) - (targetWidth / 2)
-                    targetY = (frame.height / 2) - (targetHeight / 2)
+                    cropWidth = frame.width
+                    cropHeight = frame.width / targetAspectRatio
                 }
-                Log.i(TAG, "Target size: $targetWidth x $targetHeight")
+                cropX = (frame.width / 2) - (cropWidth / 2)
+                cropY = (frame.height / 2) - (cropHeight / 2)
+                Log.i(TAG, "Cropping to $cropWidth x $cropHeight at ($cropX, $cropY)")
+            } else {
+                Log.i(TAG, "Both scale and crop are null, using Frame's original dimensions.")
             }
         }
 
@@ -81,8 +111,9 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
         }
 
         val resized = resize(frame.image,
-                targetX, targetY,
-                targetWidth, targetHeight,
+                cropX, cropY,
+                cropWidth, cropHeight,
+                scaleWidth, scaleHeight,
                 targetFormat.ordinal, targetType.ordinal)
         return SharedArray(proxy, resized)
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1116,7 +1116,7 @@ PODS:
     - React-logger (= 0.73.2)
     - React-perflogger (= 0.73.2)
   - SocketRocket (0.6.1)
-  - vision-camera-resize-plugin (1.1.0):
+  - vision-camera-resize-plugin (1.2.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1388,7 +1388,7 @@ SPEC CHECKSUMS:
   React-utils: f5bc61e7ea3325c0732ae2d755f4441940163b85
   ReactCommon: 45b5d4f784e869c44a6f5a8fad5b114ca8f78c53
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  vision-camera-resize-plugin: 7c7c5d113455f3ec76a0f582e6e75b2c2e141dda
+  vision-camera-resize-plugin: ee0f8d5a040dcee7c1d8829c502b6c899c1b4af8
   VisionCamera: edbcd00e27a438b2228f67823e2b8d15a189065f
   Yoga: 13c8ef87792450193e117976337b8527b49e8c03
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -29,10 +29,7 @@ export default function App() {
     const targetHeight = 250;
 
     const result = plugin.resize(frame, {
-      size: {
-        // Center-crop
-        x: frame.width / 2 - targetWidth / 2,
-        y: frame.height / 2 - targetHeight / 2,
+      scale: {
         width: targetWidth,
         height: targetHeight,
       },

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -289,7 +289,7 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   CGFloat cropHeight = crop.size.height;
   CGFloat cropX = crop.origin.x;
   CGFloat cropY = crop.origin.y;
-  
+
   CGFloat scaleWidth = scale.width;
   CGFloat scaleHeight = scale.height;
 
@@ -421,7 +421,7 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   } else {
     NSLog(@"ResizePlugin: No custom scale supplied.");
   }
-  
+
   double cropWidth = (double) frame.width;
   double cropHeight = (double) frame.height;
   double cropX = 0;
@@ -437,15 +437,15 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     if (scale != nil) {
       double aspectRatio = frame.width / frame.height;
       double targetAspectRatio = scaleWidth / scaleHeight;
-      
+
       if (aspectRatio > targetAspectRatio) {
         // 1920x1080
-        cropWidth = frame.height * targetAspectRatio;
+        cropWidth = frame.width * targetAspectRatio;
         cropHeight = frame.height;
       } else {
         // 1080x1920
         cropWidth = frame.width;
-        cropHeight = frame.width / targetAspectRatio;
+        cropHeight = frame.height / targetAspectRatio;
       }
       cropX = (frame.width / 2) - (cropWidth / 2);
       cropY = (frame.height / 2) - (cropHeight / 2);

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -440,7 +440,7 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
       
       if (aspectRatio > targetAspectRatio) {
         // 1920x1080
-        cropWidth = frame.width * targetAspectRatio;
+        cropWidth = frame.height * targetAspectRatio;
         cropHeight = frame.height;
       } else {
         // 1080x1920

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -289,7 +289,7 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   CGFloat cropHeight = crop.size.height;
   CGFloat cropX = crop.origin.x;
   CGFloat cropY = crop.origin.y;
-
+  
   CGFloat scaleWidth = scale.width;
   CGFloat scaleHeight = scale.height;
 
@@ -421,7 +421,7 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   } else {
     NSLog(@"ResizePlugin: No custom scale supplied.");
   }
-
+  
   double cropWidth = (double) frame.width;
   double cropHeight = (double) frame.height;
   double cropX = 0;
@@ -437,15 +437,15 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     if (scale != nil) {
       double aspectRatio = frame.width / frame.height;
       double targetAspectRatio = scaleWidth / scaleHeight;
-
+      
       if (aspectRatio > targetAspectRatio) {
         // 1920x1080
-        cropWidth = frame.width * targetAspectRatio;
+        cropWidth = frame.height * targetAspectRatio;
         cropHeight = frame.height;
       } else {
         // 1080x1920
         cropWidth = frame.width;
-        cropHeight = frame.height / targetAspectRatio;
+        cropHeight = frame.width / targetAspectRatio;
       }
       cropX = (frame.width / 2) - (cropWidth / 2);
       cropY = (frame.height / 2) - (cropHeight / 2);

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -289,7 +289,7 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   CGFloat cropHeight = crop.size.height;
   CGFloat cropX = crop.origin.x;
   CGFloat cropY = crop.origin.y;
-  
+
   CGFloat scaleWidth = scale.width;
   CGFloat scaleHeight = scale.height;
 
@@ -421,7 +421,7 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   } else {
     NSLog(@"ResizePlugin: No custom scale supplied.");
   }
-  
+
   double cropWidth = (double) frame.width;
   double cropHeight = (double) frame.height;
   double cropX = 0;
@@ -435,9 +435,9 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     NSLog(@"ResizePlugin: Cropping to %f x %f, at (%f, %f)", cropWidth, cropHeight, cropX, cropY);
   } else {
     if (scale != nil) {
-      double aspectRatio = frame.width / frame.height;
+      double aspectRatio = (double) frame.width / (double) frame.height;
       double targetAspectRatio = scaleWidth / scaleHeight;
-      
+
       if (aspectRatio > targetAspectRatio) {
         // 1920x1080
         cropWidth = frame.height * targetAspectRatio;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,15 @@ interface Rect extends Size {
 
 interface Options<T extends DataType> {
   /**
-   * Scale the image to the given target size.
-   * - If `x` and `y` are set, the plugin will crop to the target origin.
-   * - If `x` and `y` are not set, the plugin will perform a center-crop of the image.
+   * Crops the image to the given target rect. This is applied first before scaling.
+   *
+   * If this is not set, a center-crop to the given target aspect ratio is automatically calculated.
    */
-  size?: Size | Rect;
+  crop?: Rect;
+  /**
+   * Scale the image to the given target size. This is applied after cropping.
+   */
+  scale?: Size;
   /**
    * Convert the Frame to the given target pixel format.
    *


### PR DESCRIPTION
Adds a `crop` parameter that defines how to crop the image.

 Previously, the images were only scaled so that the resulting image was stretched as the aspect ratios were not respected.

Now, you can explicitly crop the buffer. **By default, it will perform a center crop, so you can leave it null**.