### PR TITLE
fix: Fix missing arguments in native func decl on Android

### DIFF
--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -39,6 +39,8 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
     cropHeight: Int,
     scaleWidth: Int,
     scaleHeight: Int,
+    rotationDegrees: Int,
+    mirror: Boolean,
     pixelFormat: Int,
     dataType: Int
   ): ByteBuffer


### PR DESCRIPTION
We were missing the two new arguments in the native function declaration. cc @rodgomesc 

Fixes #44