### PR TITLE
fix: Optimize iOS/Android codebases (type-safety and performance)

### DIFF
--- a/android/src/main/cpp/ResizePlugin.cpp
+++ b/android/src/main/cpp/ResizePlugin.cpp
@@ -63,12 +63,12 @@ libyuv::RotationMode getRotationModeForRotation(Rotation rotation) {
   }
 }
 
-int FrameBuffer::bytesPerRow() {
+int FrameBuffer::bytesPerRow() const {
   size_t bytesPerPixel = getBytesPerPixel(pixelFormat, dataType);
   return width * bytesPerPixel;
 }
 
-uint8_t* FrameBuffer::data() {
+uint8_t* FrameBuffer::data() const {
   return buffer->getDirectBytes();
 }
 
@@ -216,9 +216,10 @@ FrameBuffer ResizePlugin::rotateARGBBuffer(const FrameBuffer& frameBuffer, Rotat
   size_t channels = getChannelCount(PixelFormat::ARGB);
   size_t channelSize = getBytesPerChannel(DataType::UINT8);
   size_t destinationStride = rotatedWidth * channels * channelSize;
+  size_t rotateSize = frameBuffer.buffer->getDirectSize();
 
-  if (_rotatedBuffer == nullptr || _rotatedBuffer->getDirectSize() != frameBuffer.buffer->getDirectSize()) {
-    _rotatedBuffer = allocateBuffer(argbSize, "_rotatedBuffer");
+  if (_rotatedBuffer == nullptr || _rotatedBuffer->getDirectSize() != rotateSize) {
+    _rotatedBuffer = allocateBuffer(rotateSize, "_rotatedBuffer");
   }
 
   FrameBuffer destination = {

--- a/android/src/main/cpp/ResizePlugin.h
+++ b/android/src/main/cpp/ResizePlugin.h
@@ -21,6 +21,8 @@ enum PixelFormat { RGB, BGR, ARGB, RGBA, BGRA, ABGR };
 
 enum DataType { UINT8, FLOAT32 };
 
+enum Rotation { Rotation0, Rotation90, Rotation180, Rotation270 };
+
 struct FrameBuffer {
   int width;
   int height;
@@ -41,16 +43,16 @@ private:
   explicit ResizePlugin(const alias_ref<jhybridobject>& javaThis);
 
   global_ref<JByteBuffer> resize(alias_ref<JImage> image, int cropX, int cropY, int cropWidth, int cropHeight, int scaleWidth,
-                                 int scaleHeight, int rotation, bool mirror, int /* PixelFormat */ pixelFormat,
+                                 int scaleHeight, int /* Rotation */ rotation, bool mirror, int /* PixelFormat */ pixelFormat,
                                  int /* DataType */ dataType);
 
   FrameBuffer imageToFrameBuffer(alias_ref<JImage> image);
-  FrameBuffer cropARGBBuffer(FrameBuffer frameBuffer, int x, int y, int width, int height);
-  FrameBuffer scaleARGBBuffer(FrameBuffer frameBuffer, int width, int height);
-  FrameBuffer convertARGBBufferTo(FrameBuffer frameBuffer, PixelFormat toFormat);
-  FrameBuffer convertBufferToDataType(FrameBuffer frameBuffer, DataType dataType);
-  FrameBuffer rotateARGBBuffer(FrameBuffer frameBuffer, int rotation);
-  FrameBuffer mirrorARGBBuffer(FrameBuffer frameBuffer, bool mirror);
+  FrameBuffer cropARGBBuffer(const FrameBuffer& frameBuffer, int x, int y, int width, int height);
+  FrameBuffer scaleARGBBuffer(const FrameBuffer& frameBuffer, int width, int height);
+  FrameBuffer convertARGBBufferTo(const FrameBuffer& frameBuffer, PixelFormat toFormat);
+  FrameBuffer convertBufferToDataType(const FrameBuffer& frameBuffer, DataType dataType);
+  FrameBuffer rotateARGBBuffer(const FrameBuffer& frameBuffer, Rotation rotation);
+  FrameBuffer mirrorARGBBuffer(const FrameBuffer& frameBuffer, bool mirror);
   global_ref<JByteBuffer> allocateBuffer(size_t size, std::string debugName);
 
 private:

--- a/android/src/main/cpp/ResizePlugin.h
+++ b/android/src/main/cpp/ResizePlugin.h
@@ -30,8 +30,8 @@ struct FrameBuffer {
   DataType dataType;
   global_ref<JByteBuffer> buffer;
 
-  uint8_t* data();
-  int bytesPerRow();
+  uint8_t* data() const;
+  int bytesPerRow() const;
 };
 
 struct ResizePlugin : public HybridClass<ResizePlugin> {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -944,7 +944,7 @@ PODS:
   - React-Mapbuffer (0.73.2):
     - glog
     - React-debug
-  - react-native-worklets-core (0.2.4):
+  - react-native-worklets-core (1.2.0):
     - React
     - React-callinvoker
     - React-Core
@@ -1116,16 +1116,23 @@ PODS:
     - React-logger (= 0.73.2)
     - React-perflogger (= 0.73.2)
   - SocketRocket (0.6.1)
-  - vision-camera-resize-plugin (2.0.0):
+  - vision-camera-resize-plugin (2.1.1):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - VisionCamera
-  - VisionCamera (3.8.2):
+  - VisionCamera (4.0.1):
+    - VisionCamera/Core (= 4.0.1)
+    - VisionCamera/FrameProcessors (= 4.0.1)
+    - VisionCamera/React (= 4.0.1)
+  - VisionCamera/Core (4.0.1)
+  - VisionCamera/FrameProcessors (4.0.1):
     - React
     - React-callinvoker
-    - React-Core
     - react-native-worklets-core
+  - VisionCamera/React (4.0.1):
+    - React-Core
+    - VisionCamera/FrameProcessors
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -1367,7 +1374,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 03644c063fc3621c9a4e8bf263a8150909129618
   React-logger: 66b168e2b2bee57bd8ce9e69f739d805732a5570
   React-Mapbuffer: 9ee041e1d7be96da6d76a251f92e72b711c651d6
-  react-native-worklets-core: b4094f51cb2bc649e297206425cb8956f4945e3e
+  react-native-worklets-core: a316975bba20b73d47aa4d41bffb0ca984ba592e
   React-nativeconfig: d753fbbc8cecc8ae413d615599ac378bbf6999bb
   React-NativeModulesApple: 964f4eeab1b4325e8b6a799cf4444c3fd4eb0a9c
   React-perflogger: 29efe63b7ef5fbaaa50ef6eaa92482f98a24b97e
@@ -1389,9 +1396,9 @@ SPEC CHECKSUMS:
   React-utils: f5bc61e7ea3325c0732ae2d755f4441940163b85
   ReactCommon: 45b5d4f784e869c44a6f5a8fad5b114ca8f78c53
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  vision-camera-resize-plugin: 627fad747d8eb56033cd1a0ebd4581d26794e82d
-  VisionCamera: edbcd00e27a438b2228f67823e2b8d15a189065f
-  Yoga: 13c8ef87792450193e117976337b8527b49e8c03
+  vision-camera-resize-plugin: 5c457b56688c34d03352ea2ee66f975f0c3f3642
+  VisionCamera: 8e00df84a76cf26ca70ecd3b6ed05dc0d3b60beb
+  Yoga: e64aa65de36c0832d04e8c7bd614396c77a80047
 
 PODFILE CHECKSUM: 9cf228fb4a0a05c32bc602c7f07154b180219b9e
 

--- a/example/package.json
+++ b/example/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-native": "^0.73.2",
-    "react-native-vision-camera": "^3.8.2",
-    "react-native-worklets-core": "^0.2.4"
+    "react-native-vision-camera": "^4.0.1",
+    "react-native-worklets-core": "^1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3711,15 +3711,15 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-native-vision-camera@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-3.8.2.tgz#f4f75f84c6a19e1c3474ddc0f7f785b5a526739b"
-  integrity sha512-MY39l2e3hNRPUefn2JPShOFExcw0PblbAcUGvJrIfS9pMzdIyceo0umRAx8lOGXzDUAdb+xy/tFWb8zGxKimCQ==
+react-native-vision-camera@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-4.0.1.tgz#045c8ff9c236d3bf7e1dba24172a4c11b19bbd37"
+  integrity sha512-TuXLw/ak+LPaJOCuUaYG1g2EmTAEEeIVAhSbCsqEHlklMjkO0oRBGcPC6HpKw3++jkcKRBVVyY48HbB002UZfg==
 
-react-native-worklets-core@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-0.2.4.tgz#a4a79c04f2c6769ff03e96b7529c8638c88fa560"
-  integrity sha512-NKqxLRDOYfO7RJRZHHDA/1yztdiSadSTTILgHw2VwSrcQcmnWAZGXWr9EYpzKblpbk/vXfJa6QpWIKHjNrbe4w==
+react-native-worklets-core@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-1.2.0.tgz#155040a48d1e3f66107544867ec579c2f5044271"
+  integrity sha512-Uuf1Hg4V1w4I8eYNinwnnf+h+2YdQgwkUDQszY2yEEXWPWcZBWec0xjYn079RFRcKmGWuJ/zOtokjwy/IjJ9Fw==
   dependencies:
     string-hash-64 "^1.0.3"
 

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -440,8 +440,8 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
                                                  proxy:_proxy];
   }
 
-  vImage_Buffer* src = buffer.imageBuffer;
-  vImage_Buffer* dest = _rotateBuffer.imageBuffer;
+  const vImage_Buffer* src = buffer.imageBuffer;
+  const vImage_Buffer* dest = _rotateBuffer.imageBuffer;
 
   vImage_Error error = kvImageNoError;
   Pixel_8888 backgroundColor = {0, 0, 0, 0};
@@ -504,10 +504,10 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     NSLog(@"ResizePlugin: No custom scale supplied.");
   }
 
-  NSString* rotationParam = arguments[@"rotation"];
+  NSString* rotationString = arguments[@"rotation"];
   Rotation rotation;
-  if (rotationParam != nil) {
-    rotation = [self parseRotationFromString:rotationParam];
+  if (rotationString != nil) {
+    rotation = parseRotation(rotationString);
     NSLog(@"ResizePlugin: Rotation: %ld", (long)rotation);
   } else {
     rotation = Rotation0;

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -65,8 +65,8 @@ Rotation parseRotation(NSString* rotationString) {
   } else {
     [[unlikely]];
     @throw [NSException exceptionWithName:@"Invalid Rotation"
-                                    reason:[NSString stringWithFormat:@"Invalid rotation value! (%@)", rotationString]
-                                  userInfo:nil];
+                                   reason:[NSString stringWithFormat:@"Invalid rotation value! (%@)", rotationString]
+                                 userInfo:nil];
   }
 }
 
@@ -86,8 +86,8 @@ ConvertPixelFormat parsePixelFormat(NSString* pixelFormat) {
   } else {
     [[unlikely]];
     @throw [NSException exceptionWithName:@"Invalid PixelFormat"
-                                  reason:[NSString stringWithFormat:@"Invalid PixelFormat passed! (%@)", pixelFormat]
-                                userInfo:nil];
+                                   reason:[NSString stringWithFormat:@"Invalid PixelFormat passed! (%@)", pixelFormat]
+                                 userInfo:nil];
   }
 }
 
@@ -99,8 +99,8 @@ ConvertDataType parseDataType(NSString* dataType) {
   } else {
     [[unlikely]];
     @throw [NSException exceptionWithName:@"Invalid DataType"
-                                  reason:[NSString stringWithFormat:@"Invalid DataType passed! (%@)", dataType]
-                                userInfo:nil];
+                                   reason:[NSString stringWithFormat:@"Invalid DataType passed! (%@)", dataType]
+                                 userInfo:nil];
   }
 }
 
@@ -137,8 +137,8 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     default:
       [[unlikely]];
       @throw [NSException exceptionWithName:@"Unknown YUV pixel format!"
-                                    reason:@"Frame Pixel format is not supported in vImage_YpCbCrPixelRange!"
-                                  userInfo:nil];
+                                     reason:@"Frame Pixel format is not supported in vImage_YpCbCrPixelRange!"
+                                   userInfo:nil];
   }
 }
 
@@ -376,9 +376,7 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     }
     default:
       [[unlikely]];
-      @throw [NSException exceptionWithName:@"Unknown target data type!"
-                                    reason:@"Data type was unknown"
-                                  userInfo:nil];
+      @throw [NSException exceptionWithName:@"Unknown target data type!" reason:@"Data type was unknown" userInfo:nil];
   }
 
   if (error != kvImageNoError) {
@@ -450,27 +448,27 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   vImage_Error error = kvImageNoError;
   Pixel_8888 backgroundColor = {0, 0, 0, 0};
   switch (rotation) {
-  case Rotation90:
-    error = vImageRotate90_ARGB8888(src, dest, kRotate90DegreesClockwise, backgroundColor, kvImageNoFlags);
-    break;
-  case Rotation180:
-    error = vImageRotate90_ARGB8888(src, dest, kRotate180DegreesClockwise, backgroundColor, kvImageNoFlags);
-    break;
-  case Rotation270:
-    error = vImageRotate90_ARGB8888(src, dest, kRotate270DegreesClockwise, backgroundColor, kvImageNoFlags);
-    break;
-  default:
-    [[unlikely]];
-    @throw [NSException exceptionWithName:@"Invalid Rotation"
-                                  reason:[NSString stringWithFormat:@"Invalid Rotation! (%zu)", rotation]
-                                userInfo:nil];
+    case Rotation90:
+      error = vImageRotate90_ARGB8888(src, dest, kRotate90DegreesClockwise, backgroundColor, kvImageNoFlags);
+      break;
+    case Rotation180:
+      error = vImageRotate90_ARGB8888(src, dest, kRotate180DegreesClockwise, backgroundColor, kvImageNoFlags);
+      break;
+    case Rotation270:
+      error = vImageRotate90_ARGB8888(src, dest, kRotate270DegreesClockwise, backgroundColor, kvImageNoFlags);
+      break;
+    default:
+      [[unlikely]];
+      @throw [NSException exceptionWithName:@"Invalid Rotation"
+                                     reason:[NSString stringWithFormat:@"Invalid Rotation! (%zu)", rotation]
+                                   userInfo:nil];
   }
 
   if (error != kvImageNoError) {
     [[unlikely]];
     @throw [NSException exceptionWithName:@"Rotation Error"
-                                  reason:[NSString stringWithFormat:@"Failed to rotate ARGB buffer! Error %ld", error]
-                                userInfo:nil];
+                                   reason:[NSString stringWithFormat:@"Failed to rotate ARGB buffer! Error %ld", error]
+                                 userInfo:nil];
   }
 
   return _rotateBuffer;

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSInteger, Rotation) { Rotation0 = 0, Rotation90 = 90, Rotation1
   free(_tempResizeBuffer);
 }
 
-- (Rotation)parseRotationFromString:(NSString*)rotationString {
+Rotation parseRotation(NSString* rotationString) {
   if ([rotationString isEqualToString:@"0deg"]) {
     return Rotation0;
   } else if ([rotationString isEqualToString:@"90deg"]) {
@@ -63,44 +63,45 @@ typedef NS_ENUM(NSInteger, Rotation) { Rotation0 = 0, Rotation90 = 90, Rotation1
   } else if ([rotationString isEqualToString:@"270deg"]) {
     return Rotation270;
   } else {
-    @throw [NSException exceptionWithName:@"InvalidRotationValueException"
-                                   reason:[NSString stringWithFormat:@"Invalid rotation value! (%@)", rotationString]
-                                 userInfo:nil];
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"Invalid Rotation"
+                                    reason:[NSString stringWithFormat:@"Invalid rotation value! (%@)", rotationString]
+                                  userInfo:nil];
   }
 }
 
 ConvertPixelFormat parsePixelFormat(NSString* pixelFormat) {
   if ([pixelFormat isEqualToString:@"rgb"]) {
     return RGB;
-  }
-  if ([pixelFormat isEqualToString:@"rgba"]) {
+  } else if ([pixelFormat isEqualToString:@"rgba"]) {
     return RGBA;
-  }
-  if ([pixelFormat isEqualToString:@"argb"]) {
+  } else if ([pixelFormat isEqualToString:@"argb"]) {
     return ARGB;
-  }
-  if ([pixelFormat isEqualToString:@"bgra"]) {
+  } else if ([pixelFormat isEqualToString:@"bgra"]) {
     return BGRA;
-  }
-  if ([pixelFormat isEqualToString:@"bgr"]) {
+  } else if ([pixelFormat isEqualToString:@"bgr"]) {
     return BGR;
-  }
-  if ([pixelFormat isEqualToString:@"abgr"]) {
+  } else if ([pixelFormat isEqualToString:@"abgr"]) {
     return ABGR;
+  } else {
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"Invalid PixelFormat"
+                                  reason:[NSString stringWithFormat:@"Invalid PixelFormat passed! (%@)", pixelFormat]
+                                userInfo:nil];
   }
-  [NSException raise:@"Invalid PixelFormat" format:@"Invalid PixelFormat passed! (%@)", pixelFormat];
-  return RGB;
 }
 
 ConvertDataType parseDataType(NSString* dataType) {
   if ([dataType isEqualToString:@"uint8"]) {
     return UINT8;
-  }
-  if ([dataType isEqualToString:@"float32"]) {
+  } else if ([dataType isEqualToString:@"float32"]) {
     return FLOAT32;
+  } else {
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"Invalid DataType"
+                                  reason:[NSString stringWithFormat:@"Invalid DataType passed! (%@)", dataType]
+                                userInfo:nil];
   }
-  [NSException raise:@"Invalid DataType" format:@"Invalid DataType passed! (%@)", dataType];
-  return UINT8;
 }
 
 FourCharCode getFramePixelFormat(Frame* frame) {
@@ -134,8 +135,10 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
       return (vImage_YpCbCrPixelRange){16, 128, 235, 240, 235, 16, 240, 16};
     default:
-      [NSException raise:@"Unknown YUV pixel format!" format:@"Frame Pixel format is not supported in vImage_YpCbCrPixelRange!"];
-      return (vImage_YpCbCrPixelRange){};
+      [[unlikely]];
+      @throw [NSException exceptionWithName:@"Unknown YUV pixel format!"
+                                    reason:@"Frame Pixel format is not supported in vImage_YpCbCrPixelRange!"
+                                  userInfo:nil];
   }
 }
 
@@ -150,7 +153,10 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   error = vImageConvert_YpCbCrToARGB_GenerateConversion(kvImage_YpCbCrToARGBMatrix_ITU_R_601_4, &range, &info, sourcevImageFormat,
                                                         targetType, kvImageNoFlags);
   if (error != kvImageNoError) {
-    [NSException raise:@"YUV -> RGB conversion error" format:@"Failed to create YUV -> RGB conversion! Error: %zu", error];
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"YUV -> RGB conversion error"
+                                   reason:[NSString stringWithFormat:@"Failed to create YUV -> RGB conversion! Error: %zu", error]
+                                 userInfo:nil];
   }
 
   CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(frame.buffer);
@@ -172,7 +178,10 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
 
   error = vImageConvert_420Yp8_CbCr8ToARGB8888(&sourceY, &sourceCbCr, destination, &info, nil, 255, kvImageNoFlags);
   if (error != kvImageNoError) {
-    [NSException raise:@"YUV -> RGB conversion error" format:@"Failed to run YUV -> RGB conversion! Error: %zu", error];
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"YUV -> RGB conversion error"
+                                   reason:[NSString stringWithFormat:@"Failed to run YUV -> RGB conversion! Error: %zu", error]
+                                 userInfo:nil];
   }
 
   CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
@@ -243,7 +252,10 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   }
 
   if (error != kvImageNoError) {
-    [NSException raise:@"RGB Conversion Error" format:@"Failed to convert RGB layout! Error: %zu", error];
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"RGB Conversion Error"
+                                   reason:[NSString stringWithFormat:@"Failed to convert RGB layout! Error: %zu", error]
+                                 userInfo:nil];
   }
 
   return destinationBuffer;
@@ -266,7 +278,10 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   uint8_t permuteMap[4] = {3, 2, 1, 0};
   vImage_Error error = vImagePermuteChannels_ARGB8888(&input, destination, permuteMap, kvImageNoFlags);
   if (error != kvImageNoError) {
-    [NSException raise:@"RGB Conversion Error" format:@"Failed to convert Frame to ARGB! Error: %zu", error];
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"RGB Conversion Error"
+                                   reason:[NSString stringWithFormat:@"Failed to convert Frame to ARGB! Error: %zu", error]
+                                 userInfo:nil];
   }
 
   CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
@@ -322,7 +337,10 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   // Resize
   vImage_Error error = vImageScale_ARGB8888(source, destination, _tempResizeBuffer, kvImageNoFlags);
   if (error != kvImageNoError) {
-    [NSException raise:@"Resize Error" format:@"Failed to resize ARGB buffer! Error: %zu", error];
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"Resize Error"
+                                   reason:[NSString stringWithFormat:@"Failed to resize ARGB buffer! Error: %zu", error]
+                                 userInfo:nil];
   }
 
   return _resizeBuffer;
@@ -357,12 +375,17 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
       break;
     }
     default:
-      [NSException raise:@"Unknown target data type!" format:@"Data type was unknown."];
-      break;
+      [[unlikely]];
+      @throw [NSException exceptionWithName:@"Unknown target data type!"
+                                    reason:@"Data type was unknown"
+                                  userInfo:nil];
   }
 
   if (error != kvImageNoError) {
-    [NSException raise:@"Resize Error" format:@"Failed to convert uint8 to float! Error: %zu", error];
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"Resize Error"
+                                   reason:[NSString stringWithFormat:@"Failed to convert uint8 to float! Error: %zu", error]
+                                 userInfo:nil];
   }
 
   return _customTypeBuffer;
@@ -389,14 +412,17 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
 
   vImage_Error error = vImageHorizontalReflect_ARGB8888(&src, &dest, kvImageNoFlags);
   if (error != kvImageNoError) {
-    [NSException raise:@"Mirror Error" format:@"Failed to mirror ARGB buffer! Error: %ld", error];
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"Mirror Error"
+                                   reason:[NSString stringWithFormat:@"Failed to mirror ARGB buffer! Error: %zu", error]
+                                 userInfo:nil];
   }
 
   return _mirrorBuffer;
 }
 
-- (FrameBuffer*)rotateARGBBuffer:(FrameBuffer*)buffer rotation:(int)rotation {
-  if (rotation == 0) {
+- (FrameBuffer*)rotateARGBBuffer:(FrameBuffer*)buffer rotation:(Rotation)rotation {
+  if (rotation == Rotation0) {
     return buffer;
   }
 
@@ -404,13 +430,11 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
 
   int rotatedWidth = buffer.width;
   int rotatedHeight = buffer.height;
-  if (rotation == 90 || rotation == 270) {
+  if (rotation == Rotation90 || rotation == Rotation270) {
     int temp = rotatedWidth;
     rotatedWidth = rotatedHeight;
     rotatedHeight = temp;
   }
-
-  size_t bytesPerPixel = [FrameBuffer getBytesPerPixel:buffer.pixelFormat withType:buffer.dataType];
 
   if (_rotateBuffer == nil || _rotateBuffer.width != rotatedWidth || _rotateBuffer.height != rotatedHeight) {
     _rotateBuffer = [[FrameBuffer alloc] initWithWidth:rotatedWidth
@@ -420,28 +444,33 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
                                                  proxy:_proxy];
   }
 
-  vImage_Buffer src = *buffer.imageBuffer;
-  vImage_Buffer dest = *_rotateBuffer.imageBuffer;
+  vImage_Buffer* src = buffer.imageBuffer;
+  vImage_Buffer* dest = _rotateBuffer.imageBuffer;
 
   vImage_Error error = kvImageNoError;
   Pixel_8888 backgroundColor = {0, 0, 0, 0};
-  if (rotation == 90) {
-    error = vImageRotate90_ARGB8888(&src, &dest, kRotate90DegreesClockwise, backgroundColor, kvImageNoFlags);
-  } else if (rotation == 180) {
-    error = vImageRotate90_ARGB8888(&src, &dest, kRotate180DegreesClockwise, backgroundColor, kvImageNoFlags);
-  } else if (rotation == 270) {
-    error = vImageRotate90_ARGB8888(&src, &dest, kRotate270DegreesClockwise, backgroundColor, kvImageNoFlags);
-  } else {
-    [NSException raise:@"Invalid Rotation" format:@"Rotation must be 0, 90, 180, or 270 degrees."];
-    return nil;
+  switch (rotation) {
+  case Rotation90:
+    error = vImageRotate90_ARGB8888(src, dest, kRotate90DegreesClockwise, backgroundColor, kvImageNoFlags);
+    break;
+  case Rotation180:
+    error = vImageRotate90_ARGB8888(src, dest, kRotate180DegreesClockwise, backgroundColor, kvImageNoFlags);
+    break;
+  case Rotation270:
+    error = vImageRotate90_ARGB8888(src, dest, kRotate270DegreesClockwise, backgroundColor, kvImageNoFlags);
+    break;
+  default:
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"Invalid Rotation"
+                                  reason:[NSString stringWithFormat:@"Invalid Rotation! (%zu)", rotation]
+                                userInfo:nil];
   }
 
   if (error != kvImageNoError) {
-    [NSException raise:@"Rotation Error" format:@"Failed to rotate ARGB buffer! Error: %ld", error];
-  }
-
-  if (error != kvImageNoError) {
-    [NSException raise:@"Rotation Error" format:@"Failed to rotate ARGB buffer! Error: %ld", error];
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"Rotation Error"
+                                  reason:[NSString stringWithFormat:@"Failed to rotate ARGB buffer! Error %ld", error]
+                                userInfo:nil];
   }
 
   return _rotateBuffer;
@@ -558,8 +587,10 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     // Convert BGRA -> ARGB_8888 first, only then we can operate in RGB layouts
     result = [self convertFrameToARGB:frame];
   } else {
-    [NSException raise:@"Invalid PixelFormat" format:@"Frame has invalid Pixel Format! Disable buffer compression and 10-bit HDR."];
-    return nil;
+    [[unlikely]];
+    @throw [NSException exceptionWithName:@"Invalid PixelFormat"
+                                   reason:@"Frame has invalid Pixel Format! Disable buffer compression and 10-bit HDR."
+                                 userInfo:nil];
   }
 
   // 3. Resize

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "react": "18.2.0",
     "react-native": "0.73.2",
     "react-native-builder-bob": "^0.23.2",
-    "react-native-vision-camera": "^3.8.2",
-    "react-native-worklets-core": "^0.3.0",
+    "react-native-vision-camera": "^4.0.1",
+    "react-native-worklets-core": "^1.2.0",
     "release-it": "^17.0.3",
     "turbo": "^1.10.7",
     "typescript": "^5.0.2"
@@ -81,8 +81,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-vision-camera": ">=3.8.0",
-    "react-native-worklets-core": ">=0.2.4"
+    "react-native-vision-camera": ">=4.0.1",
+    "react-native-worklets-core": ">=1.2.0"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6596,15 +6596,15 @@ react-native-builder-bob@^0.23.2:
     which "^2.0.2"
     yargs "^17.5.1"
 
-react-native-vision-camera@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-3.8.2.tgz#f4f75f84c6a19e1c3474ddc0f7f785b5a526739b"
-  integrity sha512-MY39l2e3hNRPUefn2JPShOFExcw0PblbAcUGvJrIfS9pMzdIyceo0umRAx8lOGXzDUAdb+xy/tFWb8zGxKimCQ==
+react-native-vision-camera@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-4.0.1.tgz#045c8ff9c236d3bf7e1dba24172a4c11b19bbd37"
+  integrity sha512-TuXLw/ak+LPaJOCuUaYG1g2EmTAEEeIVAhSbCsqEHlklMjkO0oRBGcPC6HpKw3++jkcKRBVVyY48HbB002UZfg==
 
-react-native-worklets-core@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-0.3.0.tgz#4d6c4c4999d3bf2f8c67fa46fdd70d8b5bc7ba0e"
-  integrity sha512-bOoo6xbl+f+mz0Q65bLkUP3FxgYt7f/Bzi0c5Yj8Ix4vQCKMtgHwafrqCNRhW32N7TpTv3+zOoyQMJwQVr/frQ==
+react-native-worklets-core@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-worklets-core/-/react-native-worklets-core-1.2.0.tgz#155040a48d1e3f66107544867ec579c2f5044271"
+  integrity sha512-Uuf1Hg4V1w4I8eYNinwnnf+h+2YdQgwkUDQszY2yEEXWPWcZBWec0xjYn079RFRcKmGWuJ/zOtokjwy/IjJ9Fw==
   dependencies:
     string-hash-64 "^1.0.3"
 


### PR DESCRIPTION
1. Improve Rotation typesafety by explicitly using the enum types, instead of unsafely casting to ints (codestyle)
2. Use `@throw` instead of `[NSException raise]` (avoid return)
3. Use `[[unlikely]]` for exceptions (performance)
4. Use `const FrameBuffer&` for arguments to avoid copy (performance)