### PR TITLE
fix: Fix libyuv convert functions calls on Android

### DIFF
--- a/android/src/main/cpp/ResizePlugin.cpp
+++ b/android/src/main/cpp/ResizePlugin.cpp
@@ -276,7 +276,7 @@ FrameBuffer ResizePlugin::convertARGBBufferTo(FrameBuffer frameBuffer, PixelForm
       // do nothing, we're already in ARGB
       return frameBuffer;
     case RGB:
-      // RAW is [B, G, R] in libyuv memory layout
+      // RAW is [R, G, B] in libyuv memory layout
       error = libyuv::ARGBToRAW(frameBuffer.data(), frameBuffer.bytesPerRow(), destination.data(), destination.bytesPerRow(),
                                 destination.width, destination.height);
       break;

--- a/android/src/main/cpp/ResizePlugin.cpp
+++ b/android/src/main/cpp/ResizePlugin.cpp
@@ -276,10 +276,12 @@ FrameBuffer ResizePlugin::convertARGBBufferTo(FrameBuffer frameBuffer, PixelForm
       // do nothing, we're already in ARGB
       return frameBuffer;
     case RGB:
+      // RAW is [B, G, R] in libyuv memory layout
       error = libyuv::ARGBToRAW(frameBuffer.data(), frameBuffer.bytesPerRow(), destination.data(), destination.bytesPerRow(),
                                 destination.width, destination.height);
       break;
     case BGR:
+      // RGB24 is [B, G, R] in libyuv memory layout
       error = libyuv::ARGBToRGB24(frameBuffer.data(), frameBuffer.bytesPerRow(), destination.data(), destination.bytesPerRow(),
                                   destination.width, destination.height);
       break;

--- a/android/src/main/cpp/ResizePlugin.cpp
+++ b/android/src/main/cpp/ResizePlugin.cpp
@@ -276,11 +276,13 @@ FrameBuffer ResizePlugin::convertARGBBufferTo(FrameBuffer frameBuffer, PixelForm
       // do nothing, we're already in ARGB
       return frameBuffer;
     case RGB:
+      error = libyuv::ARGBToRAW(frameBuffer.data(), frameBuffer.bytesPerRow(), destination.data(), destination.bytesPerRow(),
+                                destination.width, destination.height);
+      break;
+    case BGR:
       error = libyuv::ARGBToRGB24(frameBuffer.data(), frameBuffer.bytesPerRow(), destination.data(), destination.bytesPerRow(),
                                   destination.width, destination.height);
       break;
-    case BGR:
-      throw std::runtime_error("BGR is not supported on Android!");
     case RGBA:
       error = libyuv::ARGBToRGBA(frameBuffer.data(), frameBuffer.bytesPerRow(), destination.data(), destination.bytesPerRow(),
                                  destination.width, destination.height);


### PR DESCRIPTION
Fixing this issue: https://github.com/mrousavy/vision-camera-resize-plugin/issues/43
According to libyuv docs: https://chromium.googlesource.com/libyuv/libyuv/+/refs/heads/main/docs/formats.md#rgb24-and-raw
RGB24 memory layout is [B,G,R] and RAW layout is [R,G,B].
So we can call `ARGBToRAW` when converting to RGB and `ARGBToRGB24` when converting to BGR.
I tested it out with code from the issue, and now it displays correct colors.
EDIT: changed link from SO to docs link