### PR TITLE
fix: Float32 conversion on IOS

### DIFF
--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -353,7 +353,13 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
       break;
     case FLOAT32: {
       // Convert uint8 -> float32
-      error = vImageConvert_Planar8toPlanarF(source, destination, 1.0f, 0.0f, kvImageNoFlags);
+      unsigned char *input = (unsigned char *)source->data;
+      float *output = (float *)destination->data;
+
+      size_t numBytes = source->height * source->rowBytes;
+      for (size_t i = 0; i < numBytes; i++) {
+          output[i] = (input[i] / 255.0f);
+      }
       break;
     }
     default:

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -347,7 +347,6 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
   const vImage_Buffer* source = buffer.imageBuffer;
   const vImage_Buffer* destination = _customTypeBuffer.imageBuffer;
 
-  vImage_Error error = kvImageNoError;
   switch (targetType) {
     case UINT8:
       break;
@@ -355,20 +354,16 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
       // Convert uint8 -> float32
       unsigned char *input = (unsigned char *)source->data;
       float *output = (float *)destination->data;
-
       size_t numBytes = source->height * source->rowBytes;
-      for (size_t i = 0; i < numBytes; i++) {
-          output[i] = (input[i] / 255.0f);
-      }
+      float scale = 1.0f / 255.0f;
+
+      vDSP_vfltu8(input, 1, output, 1, numBytes);
+      vDSP_vsmul(output, 1, &scale, output, 1, numBytes);
       break;
     }
     default:
       [NSException raise:@"Unknown target data type!" format:@"Data type was unknown."];
       break;
-  }
-
-  if (error != kvImageNoError) {
-    [NSException raise:@"Resize Error" format:@"Failed to convert uint8 to float! Error: %zu", error];
   }
 
   return _customTypeBuffer;


### PR DESCRIPTION
Fixing this: https://github.com/mrousavy/vision-camera-resize-plugin/issues/40

Upon some digging, we found out that when using RGB (or other 3 channel formats) 1/3 of the camera is zeroed out and when using RGBA (4 channels) 1/4 of the camera is zeroed out.

This was caused by incorrect usage of [vImageConvert_Planar8toPlanarF](https://developer.apple.com/documentation/accelerate/1533188-vimageconvert_planar8toplanarf), when in reality the buffers were interleaved, not planar.

Having assumed different memory layout, the converter function acted as if the image rows were N_CHANNELS times shorter in terms of bytes than in reality, resulting in that strange behavior.

If we convert manually, this doesnt happen. I used vDSP_vfltu8, vDSP_vsmul so things go fast.