### PR TITLE
fix ARGB to RGBA conversion in IOS ResizePlugin.mm

### DIFF
--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -233,7 +233,7 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
     }
     case RGBA: {
       NSLog(@"Converting ARGB_8 Frame to RGBA_8...");
-      uint8_t permuteMap[4] = {3, 1, 2, 0};
+      uint8_t permuteMap[4] = {1, 2, 3, 0};
       error = vImagePermuteChannels_ARGB8888(source, destination, permuteMap, kvImageNoFlags);
       break;
     }


### PR DESCRIPTION
Hi, I think I found a typo in ARGB to RGBA conversion in IOS ResizePlugin.mm.

uint8_t permuteMap[4] = {3, 1, 2, 0}; from ARGB produce BRGA instead of RGBA.