### PR TITLE
fix: Fix rotation being parsed incorrectly

### DIFF
--- a/android/src/main/cpp/ResizePlugin.cpp
+++ b/android/src/main/cpp/ResizePlugin.cpp
@@ -202,6 +202,8 @@ FrameBuffer ResizePlugin::rotateARGBBuffer(const FrameBuffer& frameBuffer, Rotat
     return frameBuffer;
   }
 
+  __android_log_print(ANDROID_LOG_INFO, TAG, "Rotating ARGB buffer by %zu degrees...", static_cast<int>(rotation));
+
   int rotatedWidth, rotatedHeight;
   if (rotation == Rotation90 || rotation == Rotation270) {
     // flipped to the side

--- a/android/src/main/cpp/ResizePlugin.h
+++ b/android/src/main/cpp/ResizePlugin.h
@@ -21,7 +21,7 @@ enum PixelFormat { RGB, BGR, ARGB, RGBA, BGRA, ABGR };
 
 enum DataType { UINT8, FLOAT32 };
 
-enum Rotation { Rotation0, Rotation90, Rotation180, Rotation270 };
+enum Rotation { Rotation0 = 0, Rotation90 = 90, Rotation180 = 180, Rotation270 = 270 };
 
 struct FrameBuffer {
   int width;

--- a/ios/ResizePlugin.mm
+++ b/ios/ResizePlugin.mm
@@ -370,8 +370,8 @@ vImage_YpCbCrPixelRange getRange(FourCharCode pixelFormat) {
       break;
     case FLOAT32: {
       // Convert uint8 -> float32
-      unsigned char *input = (unsigned char *)source->data;
-      float *output = (float *)destination->data;
+      unsigned char* input = (unsigned char*)source->data;
+      float* output = (float*)destination->data;
       size_t numBytes = source->height * source->rowBytes;
       float scale = 1.0f / 255.0f;
 


### PR DESCRIPTION
We use enum values of 90, 180 and 270.

supersedes #60 