### PR TITLE
Added RGBA support for Android.

### DIFF
--- a/android/src/main/cpp/JImage.cpp
+++ b/android/src/main/cpp/JImage.cpp
@@ -24,7 +24,7 @@ int JImage::getHeight() const {
   return result;
 }
 
-int JImage::getFroamt() const {
+int JImage::getFormat() const {
   auto method = getClass()->getMethod<jint()>("getFormat");
   auto result = method(self());
   return result;

--- a/android/src/main/cpp/JImage.cpp
+++ b/android/src/main/cpp/JImage.cpp
@@ -24,6 +24,12 @@ int JImage::getHeight() const {
   return result;
 }
 
+int JImage::getFroamt() const {
+  auto method = getClass()->getMethod<jint()>("getFormat");
+  auto result = method(self());
+  return result;
+}
+
 jni::local_ref<jni::JArrayClass<JImagePlane>> JImage::getPlanes() const {
   auto method = getClass()->getMethod<jni::JArrayClass<JImagePlane>()>("getPlanes");
   auto result = method(self());

--- a/android/src/main/cpp/JImage.h
+++ b/android/src/main/cpp/JImage.h
@@ -19,6 +19,7 @@ struct JImage : public JavaClass<JImage> {
 public:
   int getWidth() const;
   int getHeight() const;
+  int getFormat() const;
   jni::local_ref<jni::JArrayClass<JImagePlane>> getPlanes() const;
 };
 

--- a/android/src/main/cpp/ResizePlugin.cpp
+++ b/android/src/main/cpp/ResizePlugin.cpp
@@ -101,24 +101,25 @@ FrameBuffer ResizePlugin::imageToFrameBuffer(alias_ref<vision::JImage> image) {
   };
 
   int sourceImageFormat = image->getFormat();
+  int status;
 
   switch (sourceImageFormat) {
-    case SourceImageFormat::RGBA_8888:
-
+    case SourceImageFormat::RGBA_8888: {
       __android_log_write(ANDROID_LOG_INFO, TAG, "Converting RGBA 8888 -> ARGB 8888...");
       jni::local_ref<JImagePlane> rgbaPlane = planes->getElement(0);
       jni::local_ref<JByteBuffer> rgbaBuffer = rgbaPlane->getBuffer();
       // 1. Convert from RGBA -> ARGB
-      int status = libyuv::RGBAToARGB(rgbaBuffer->getDirectBytes(), rgbaPlane->getRowStride(), destination.data(),
-                                      width * channels * channelSize, width, height);
+      status = libyuv::RGBAToARGB(rgbaBuffer->getDirectBytes(), rgbaPlane->getRowStride(), destination.data(),
+                                  width * channels * channelSize, width, height);
 
       if (status != 0) {
         [[unlikely]];
         throw std::runtime_error("Failed to convert RGBA 8888 to ARGB! Error: " + std::to_string(status));
       }
       break;
-
+    }
     default: /* SourceImageFormat.YUV_420_888 */
+    {
       __android_log_write(ANDROID_LOG_INFO, TAG, "Converting YUV 4:2:0 -> ARGB 8888...");
       jni::local_ref<JImagePlane> yPlane = planes->getElement(0);
       jni::local_ref<JByteBuffer> yBuffer = yPlane->getBuffer();
@@ -134,18 +135,19 @@ FrameBuffer ResizePlugin::imageToFrameBuffer(alias_ref<vision::JImage> image) {
       }
 
       // 1. Convert from YUV -> ARGB
-      int status = libyuv::Android420ToARGB(yBuffer->getDirectBytes(), yPlane->getRowStride(), uBuffer->getDirectBytes(),
-                                            uPlane->getRowStride(), vBuffer->getDirectBytes(), vPlane->getRowStride(), uvPixelStride,
-                                            destination.data(), width * channels * channelSize, width, height);
+      status = libyuv::Android420ToARGB(yBuffer->getDirectBytes(), yPlane->getRowStride(), uBuffer->getDirectBytes(),
+                                        uPlane->getRowStride(), vBuffer->getDirectBytes(), vPlane->getRowStride(), uvPixelStride,
+                                        destination.data(), width * channels * channelSize, width, height);
 
       if (status != 0) {
         [[unlikely]];
         throw std::runtime_error("Failed to convert YUV 4:2:0 to ARGB! Error: " + std::to_string(status));
       }
       break;
+    }
   }
 
-  return destination
+  return destination;
 }
 
 std::string rectToString(int x, int y, int width, int height) {
@@ -398,8 +400,7 @@ FrameBuffer ResizePlugin::convertBufferToDataType(const FrameBuffer& frameBuffer
 
 jni::global_ref<jni::JByteBuffer> ResizePlugin::resize(jni::alias_ref<JImage> image, int cropX, int cropY, int cropWidth, int cropHeight,
                                                        int scaleWidth, int scaleHeight, int /* Rotation */ rotationOrdinal, bool mirror,
-                                                       int /* PixelFormat */ pixelFormatOrdinal, int /* DataType */ dataTypeOrdinal,
-                                                       int /* SourceImageFormat */ sourceImageFormat) {
+                                                       int /* PixelFormat */ pixelFormatOrdinal, int /* DataType */ dataTypeOrdinal) {
   PixelFormat pixelFormat = static_cast<PixelFormat>(pixelFormatOrdinal);
   DataType dataType = static_cast<DataType>(dataTypeOrdinal);
   Rotation rotation = static_cast<Rotation>(rotationOrdinal);

--- a/android/src/main/cpp/ResizePlugin.h
+++ b/android/src/main/cpp/ResizePlugin.h
@@ -19,6 +19,8 @@ using namespace jni;
 
 enum PixelFormat { RGB, BGR, ARGB, RGBA, BGRA, ABGR };
 
+enum SourceImageFormat { RGBA_8888 = 1, YUV_420_888 = 35 };
+
 enum DataType { UINT8, FLOAT32 };
 
 enum Rotation { Rotation0 = 0, Rotation90 = 90, Rotation180 = 180, Rotation270 = 270 };
@@ -44,9 +46,10 @@ private:
 
   global_ref<JByteBuffer> resize(alias_ref<JImage> image, int cropX, int cropY, int cropWidth, int cropHeight, int scaleWidth,
                                  int scaleHeight, int /* Rotation */ rotation, bool mirror, int /* PixelFormat */ pixelFormat,
-                                 int /* DataType */ dataType);
+                                 int /* DataType */ dataType, int /* SourceImageFormat */ sourceImageFormat);
 
-  FrameBuffer imageToFrameBuffer(alias_ref<JImage> image);
+  FrameBuffer imageYUVToFrameBuffer(alias_ref<JImage> image);
+  FrameBuffer imageRGBAToFrameBuffer(alias_ref<JImage> image);
   FrameBuffer cropARGBBuffer(const FrameBuffer& frameBuffer, int x, int y, int width, int height);
   FrameBuffer scaleARGBBuffer(const FrameBuffer& frameBuffer, int width, int height);
   FrameBuffer convertARGBBufferTo(const FrameBuffer& frameBuffer, PixelFormat toFormat);

--- a/android/src/main/cpp/ResizePlugin.h
+++ b/android/src/main/cpp/ResizePlugin.h
@@ -19,6 +19,7 @@ using namespace jni;
 
 enum PixelFormat { RGB, BGR, ARGB, RGBA, BGRA, ABGR };
 
+/* Those should match Android ImageFormat and PixelFormat constants */
 enum SourceImageFormat { RGBA_8888 = 1, YUV_420_888 = 35 };
 
 enum DataType { UINT8, FLOAT32 };
@@ -46,10 +47,9 @@ private:
 
   global_ref<JByteBuffer> resize(alias_ref<JImage> image, int cropX, int cropY, int cropWidth, int cropHeight, int scaleWidth,
                                  int scaleHeight, int /* Rotation */ rotation, bool mirror, int /* PixelFormat */ pixelFormat,
-                                 int /* DataType */ dataType, int /* SourceImageFormat */ sourceImageFormat);
+                                 int /* DataType */ dataType);
 
-  FrameBuffer imageYUVToFrameBuffer(alias_ref<JImage> image);
-  FrameBuffer imageRGBAToFrameBuffer(alias_ref<JImage> image);
+  FrameBuffer imageToFrameBuffer(alias_ref<JImage> image);
   FrameBuffer cropARGBBuffer(const FrameBuffer& frameBuffer, int x, int y, int width, int height);
   FrameBuffer scaleARGBBuffer(const FrameBuffer& frameBuffer, int width, int height);
   FrameBuffer convertARGBBufferTo(const FrameBuffer& frameBuffer, PixelFormat toFormat);

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -1,6 +1,7 @@
 package com.visioncameraresizeplugin
 
 import android.graphics.ImageFormat
+import android.graphics.PixelFormat as AndroidPixelFormat
 import android.media.Image
 import android.util.Log
 import androidx.annotation.Keep
@@ -42,7 +43,8 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
     rotation: Int,
     mirror: Boolean,
     pixelFormat: Int,
-    dataType: Int
+    dataType: Int,
+    sourceImageFormat: Int
   ): ByteBuffer
 
   override fun callback(frame: Frame, params: MutableMap<String, Any>?): Any {
@@ -141,8 +143,8 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
 
     val image = frame.image
 
-    if (image.format != ImageFormat.YUV_420_888) {
-      throw Error("Frame has invalid PixelFormat! Only YUV_420_888 is supported. Did you set pixelFormat=\"yuv\"?")
+    if (image.format != ImageFormat.YUV_420_888 && image.format != AndroidPixelFormat.RGBA_8888) {
+      throw Error("Frame has invalid PixelFormat! Only YUV_420_888 and  RGBA_8888 are supported. Did you set pixelFormat=\"yuv\" or \"rgb\"?")
     }
 
     val resized = resize(
@@ -153,7 +155,8 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
       rotation.degrees,
       mirror,
       targetFormat.ordinal,
-      targetType.ordinal
+      targetType.ordinal,
+      image.format
     )
 
     return SharedArray(proxy, resized)

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -143,11 +143,12 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
 
     val image = frame.image
 
-    if (image.format != ImageFormat.YUV_420_888 && image.format != AndroidPixelFormat.RGBA_8888) {
-      throw Error("""
-      |Frame has invalid PixelFormat! Only YUV_420_888 and  RGBA_8888 are supported. 
-      |Did you set pixelFormat=\"yuv\" or \"rgb\"?
-      """.trimMargin()
+   if (image.format != ImageFormat.YUV_420_888 && image.format != AndroidPixelFormat.RGBA_8888) {
+      throw Error(
+          """
+          |Frame has invalid PixelFormat! Only YUV_420_888 and  RGBA_8888 are supported. 
+          |Did you set pixelFormat=\"yuv\" or \"rgb\"?
+          """.trimMargin()
       )
     }
 

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -143,12 +143,12 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
 
     val image = frame.image
 
-   if (image.format != ImageFormat.YUV_420_888 && image.format != AndroidPixelFormat.RGBA_8888) {
+    if (image.format != ImageFormat.YUV_420_888 && image.format != AndroidPixelFormat.RGBA_8888) {
       throw Error(
-          """
+        """
           |Frame has invalid PixelFormat! Only YUV_420_888 and  RGBA_8888 are supported. 
           |Did you set pixelFormat=\"yuv\" or \"rgb\"?
-          """.trimMargin()
+        """.trimMargin()
       )
     }
 

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -43,8 +43,7 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
     rotation: Int,
     mirror: Boolean,
     pixelFormat: Int,
-    dataType: Int,
-    sourceImageFormat: Int
+    dataType: Int
   ): ByteBuffer
 
   override fun callback(frame: Frame, params: MutableMap<String, Any>?): Any {
@@ -160,8 +159,7 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
       rotation.degrees,
       mirror,
       targetFormat.ordinal,
-      targetType.ordinal,
-      image.format
+      targetType.ordinal
     )
 
     return SharedArray(proxy, resized)

--- a/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
+++ b/android/src/main/java/com/visioncameraresizeplugin/ResizePlugin.kt
@@ -144,7 +144,11 @@ class ResizePlugin(private val proxy: VisionCameraProxy) : FrameProcessorPlugin(
     val image = frame.image
 
     if (image.format != ImageFormat.YUV_420_888 && image.format != AndroidPixelFormat.RGBA_8888) {
-      throw Error("Frame has invalid PixelFormat! Only YUV_420_888 and  RGBA_8888 are supported. Did you set pixelFormat=\"yuv\" or \"rgb\"?")
+      throw Error("""
+      |Frame has invalid PixelFormat! Only YUV_420_888 and  RGBA_8888 are supported. 
+      |Did you set pixelFormat=\"yuv\" or \"rgb\"?
+      """.trimMargin()
+      )
     }
 
     val resized = resize(


### PR DESCRIPTION
I'm not sure about C++ and Kotlin practices, but I added function that performs RGBA -> ARGB frame buffer conversion. This way, you can use resize plugin with Skia Frame processor from vision camera v4.