### PR TITLE
fix: VisionCamera/VisionCameraProxy.h file not found

### DIFF
--- a/ios/FrameBuffer.h
+++ b/ios/FrameBuffer.h
@@ -11,7 +11,7 @@
 #import <Accelerate/Accelerate.h>
 #import <Foundation/Foundation.h>
 #import <VisionCamera/SharedArray.h>
-#import <VisionCamera/VisionCameraProxy.h>
+#import <VisionCamera/VisionCameraProxyHolder.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/FrameBuffer.mm
+++ b/ios/FrameBuffer.mm
@@ -10,7 +10,7 @@
 #import <Accelerate/Accelerate.h>
 #import <Foundation/Foundation.h>
 #import <VisionCamera/SharedArray.h>
-#import <VisionCamera/VisionCameraProxy.h>
+#import <VisionCamera/VisionCameraProxyHolder.h>
 
 @implementation FrameBuffer {
   vImage_Buffer _imageBuffer;


### PR DESCRIPTION
In v4 of VisionCamera the public headers changed from

`ios/Frame Processor/VisionCameraProxy.h`

to 

`ios/FrameProcessors/VisionCameraProxyHolder.h`

But this was not updated in vision-camera-resize-plugin.

There is an issue reported #65 that can be re-created if you install the pods with

`USE_FRAMEWORKS=static pod install`

and then a build.

With the changes in this PR, builds are successful and the example app has been successfully installed on an iPhone.