### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -122,6 +122,7 @@ android {
             "**/libreact_nativemodule_core.so",
             "**/libjscexecutor.so"
     ]
+    pickFirst "META-INF/**"
   }
 }
 


### PR DESCRIPTION
fixes detox test builds


Without this my detox tests are failing to build with:

```
> Task :vision-camera-resize-plugin:mergeDebugAndroidTestJavaResource FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':vision-camera-resize-plugin:mergeDebugAndroidTestJavaResource'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
   > 2 files found with path 'META-INF/com.android.tools/proguard/coroutines.pro' from inputs:
      - /Users/hcwiley/.gradle/caches/transforms-4/0b81ebc8b508dace44f8d6f62dc0482f/transformed/jetified-kotlinx-coroutines-core-jvm-1.8.1.jar
      - /Users/hcwiley/.gradle/caches/transforms-4/2ec830934321228e998ccb64ad5211dc/transformed/jetified-kotlinx-coroutines-android-1.8.1.jar
     Adding a packagingOptions block may help, please refer to
     https://developer.android.com/reference/tools/gradle-api/8.2/com/android/build/api/dsl/ResourcesPackagingOptions
     for more information
```