### PR TITLE
feat: Preserve Aspect Ratio Option

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -20,8 +20,8 @@ import { createSkiaImageFromData } from './SkiaUtils';
 
 type PixelFormat = Options<'uint8'>['pixelFormat'];
 
-const WIDTH = 480;
-const HEIGHT = 640;
+const WIDTH = 300;
+const HEIGHT = 300;
 const TARGET_TYPE = 'uint8' as const;
 const TARGET_FORMAT: PixelFormat = 'rgba';
 
@@ -39,8 +39,13 @@ export default function App() {
   const updatePreviewImageFromData = useRunOnJS(
     (data: SkData, pixelFormat: PixelFormat) => {
       const image = createSkiaImageFromData(data, WIDTH, HEIGHT, pixelFormat);
+      if (image == null) {
+        data.dispose();
+        return;
+      }
       previewImage.value?.dispose();
       previewImage.value = image;
+      data.dispose();
     },
     []
   );
@@ -64,11 +69,10 @@ export default function App() {
 
       const data = Skia.Data.fromBytes(result);
       updatePreviewImageFromData(data, TARGET_FORMAT);
-      data.dispose();
       const end = performance.now();
 
       console.log(
-        `Resized ${frame.width}x${frame.height} into 100x100 frame (${
+        `Resized ${frame.width}x${frame.height} into ${WIDTH}x${HEIGHT} frame (${
           result.length
         }) in ${(end - start).toFixed(2)}ms`
       );
@@ -119,5 +123,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 80,
     left: 20,
+    borderColor: '#F00',
+    borderWidth: 2,
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,11 @@ export interface Options<T extends DataType> {
    */
   scale?: Size;
   /**
+   * If set to `true`, the image will be resized to to fit within the dimensions specified by
+   * scale and padded, maintaining the aspect ratio of the original image.
+   */
+  preserveAspectRatio?: boolean;
+  /**
    * Rotate the image by a given amount of degrees, clockwise.
    * @default '0deg'
    */


### PR DESCRIPTION
Context: Many computer vision algorithms and ML models require an input in which the aspect ratio of the original image is preserved by scaling the image down equally along both axis and then pad the rest of the input space with black or white pixels. A good example of this is the image resize method in the Tensorflow framework https://www.tensorflow.org/api_docs/python/tf/image/resize

This adds an option called `preserveAspectRatio` to the resize method which does exactly this for the input as you can see in the screenshot below:

<img src="https://github.com/user-attachments/assets/4348c546-dc17-4124-a670-5d5f217491f1" width="30%" />
